### PR TITLE
pin bintray origin to priority 1000

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main @IMAGE_SUITE@ main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main @IMAGE_SUITE@ main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/amd64/Dockerfile
+++ b/stretch/amd64/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/arm64/Dockerfile
+++ b/stretch/arm64/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/armel/Dockerfile
+++ b/stretch/armel/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/armhf/Dockerfile
+++ b/stretch/armhf/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/i386/Dockerfile
+++ b/stretch/i386/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/mips/Dockerfile
+++ b/stretch/mips/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/mips64el/Dockerfile
+++ b/stretch/mips64el/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/mipsel/Dockerfile
+++ b/stretch/mipsel/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/ppc64el-next/Dockerfile
+++ b/stretch/ppc64el-next/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/ppc64el/Dockerfile
+++ b/stretch/ppc64el/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11

--- a/stretch/s390x/Dockerfile
+++ b/stretch/s390x/Dockerfile
@@ -18,8 +18,11 @@ RUN apt-get update -qq \
 		lintian \
 		sudo
 
-RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
-	&& apt-get update -qq
+RUN echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | \
+		tee /etc/apt/sources.list.d/bintray.list; \
+	(echo "Package: *"; echo "Pin: origin \"dl.bintray.com\""; echo "Pin-Priority: 1000") | \
+		tee /etc/apt/preferences.d/bintray.pref; \
+	apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.
 # See https://github.com/laarid/docker/issues/11


### PR DESCRIPTION
We have some specialized debian packages in bintray laaid repository. However, whenever Debian releases new version of any of them, a rebase/rebuild of that package has to be done in time to prevent possible unexpected build failure. So, this change will pin versions of those laarid specialized packages.